### PR TITLE
feat(ci): implement automated PyPI publishing with trusted publishing

### DIFF
--- a/.ai/specs/4-pypi/goal.md
+++ b/.ai/specs/4-pypi/goal.md
@@ -1,0 +1,20 @@
+# Goal: Support Publishing to PyPI When New Tag Created
+
+## Related Issue
+Issue #4: feat: set up PyPI publishing on version tag creation
+
+## What We Want to Accomplish
+We want to establish an automated PyPI publishing pipeline that seamlessly integrates with the existing semantic-release workflow. When semantic-release creates a new version tag, the system should automatically build and publish the txtpack package to PyPI, enabling users to install it via `uvx txtpack` or `pip install txtpack`.
+
+This automation will complete the release cycle by taking packages from version tagging directly to public availability, removing manual publishing steps and ensuring consistent, reliable releases. The solution should leverage GitHub Actions and PyPI's trusted publishing mechanism for secure, token-free deployment.
+
+## Optimization Target
+**Automation and reliability** - Optimizing for automation means eliminating manual intervention in the publishing process while ensuring the pipeline is robust and handles edge cases gracefully. This includes proper error handling, secure credential management, and integration testing to prevent failed or corrupted releases from reaching PyPI.
+
+## Out of Scope
+- Setting up publishing to alternative package repositories (conda-forge, etc.)
+- Creating custom package distribution formats beyond standard Python wheels/sdist
+- Implementing rollback mechanisms for published packages (PyPI doesn't support deletion)
+- Advanced publishing strategies like staged rollouts or canary releases
+- Documentation website deployment or hosting
+- Package analytics or download tracking setup

--- a/.ai/specs/4-pypi/plan.md
+++ b/.ai/specs/4-pypi/plan.md
@@ -1,0 +1,27 @@
+# Plan: Support Publishing to PyPI When New Tag Created
+
+## Implementation Steps
+
+### Step 1: Configure PyPI Trusted Publishing
+- Set up trusted publisher configuration in PyPI project settings
+- Configure GitHub Actions as trusted publisher for the txtpack repository
+- **Deliverable**: PyPI project configured to accept trusted publishing from GitHub Actions
+
+### Step 2: Update Semantic Release Configuration
+- Modify `.releaserc.json` exec plugin to replace placeholder `publishCmd` with `uv publish --trusted-publishing automatic`
+- **Deliverable**: Updated `.releaserc.json` with integrated PyPI publishing
+
+### Step 3: Enhance Release Workflow
+- Add `id-token: write` permission to `.github/workflows/release.yml`
+- **Deliverable**: Updated release workflow with PyPI publishing capabilities
+
+### Step 4: Update Documentation
+- Update installation instructions to include `uvx txtpack` and `pip install txtpack`
+- **Deliverable**: Updated documentation reflecting new PyPI availability
+
+## Testing Strategy
+
+### End-to-End Validation
+- Create a test release to verify complete workflow from commit to package availability
+- Verify `uvx txtpack` works after publishing
+- Confirm published package version matches git tag

--- a/.ai/specs/4-pypi/research.md
+++ b/.ai/specs/4-pypi/research.md
@@ -1,0 +1,253 @@
+# Research: Support Publishing to PyPI When New Tag Created
+
+## Issue Context
+Issue #4: feat: set up PyPI publishing on version tag creation - Set up automated PyPI publishing to enable installation via `uvx txtpack`. The publishing should trigger automatically when a new version tag is created by the semantic-release workflow.
+
+## Codebase Context
+
+### Current Project Structure
+- **Build System**: Uses `hatchling` build backend with `pyproject.toml` configuration
+- **Package Structure**: Source in `src/txtpack/` with console script entry point `txtpack = "txtpack.main:main"`
+- **Version Management**: Static version `"1.0.0"` in pyproject.toml, updated by semantic-release via sed command
+- **Development Tools**: uv for package management, Typer for CLI, Python 3.11+ requirement
+
+### Existing CI/CD Pipeline
+- **CI Workflow** (`.github/workflows/ci.yml`): Runs on push/PR to main, includes linting, formatting, type checking, and tests using uv
+- **Release Workflow** (`.github/workflows/release.yml`): Triggered after CI success, uses semantic-release with Node.js
+- **Semantic Release Config** (`.releaserc.json`): Configured with exec plugin that updates pyproject.toml version but has placeholder for PyPI publishing
+
+### Current Release Process
+1. Changes merged to main branch
+2. CI pipeline validates code quality using `uv sync --group dev` and `uv run` commands
+3. Semantic-release analyzes commits using conventional commit format
+4. Version bumped in pyproject.toml via sed command
+5. Changelog generated and GitHub release created
+6. **Missing**: PyPI publishing step (currently shows placeholder message)
+
+## External Resources
+
+### uv-Native Publishing Approach (Recommended)
+- **uv publish Command**: Native uv command for uploading distributions to PyPI
+- **Trusted Publishing Integration**: Built-in support with `--trusted-publishing automatic`
+- **Workflow Integration**: Direct `uv build` → `uv publish` pipeline
+- **Performance**: Leverages uv's Rust-based optimizations and caching
+
+### PyPI Trusted Publishing (Security Foundation)
+- **Official Documentation**: PyPI Warehouse project provides comprehensive trusted publishing guides
+- **Security Model**: Uses OpenID Connect (OIDC) tokens instead of long-lived API tokens
+- **GitHub Integration**: Native support for GitHub Actions with `id-token: write` permission
+- **uv Support**: `uv publish --trusted-publishing automatic` handles OIDC token exchange automatically
+
+### GitHub Actions uv Integration
+- **setup-uv Action**: `astral-sh/setup-uv@v6` with native caching and Python version management
+- **Build Process**: `uv build` creates wheel and sdist in `dist/` directory
+- **Publishing Process**: `uv publish --trusted-publishing automatic` handles upload
+- **Caching**: Built-in uv cache with `enable-cache: true` and dependency glob patterns
+
+### Best Practices from Research
+- Use GitHub environments (e.g., "pypi") for additional approval gates
+- Test with TestPyPI first using `uv publish --publish-url https://test.pypi.org/legacy/`
+- Leverage uv's native caching for faster workflow execution
+- Maintain uv ecosystem consistency throughout build and publish pipeline
+
+## Domain Knowledge
+
+### uv-Native Publishing Workflow
+1. **Build**: `uv build` creates distributions in `dist/` directory
+2. **Publish**: `uv publish --trusted-publishing automatic` handles:
+   - OIDC token detection in GitHub Actions environment
+   - Token exchange with PyPI for temporary API token
+   - Upload of both wheel and source distributions
+   - Automatic cleanup of temporary credentials
+
+### uv publish Command Features
+- **Default Behavior**: Uploads `dist/*` files (all distributions)
+- **Trusted Publishing**: `--trusted-publishing automatic|always|never` options
+- **Index Support**: Can target different indexes via `--publish-url` or `--index`
+- **Authentication**: Supports tokens, username/password, and keyring providers
+- **Error Handling**: Built-in duplicate detection and retry logic
+
+### Integration with Semantic Release
+- Current semantic-release config has `publishCmd` placeholder
+- **Option 1**: Update semantic-release exec plugin to use `uv publish`
+- **Option 2**: Trigger separate PyPI workflow on tag creation events
+- **Preferred**: Integrate directly into release workflow for atomic releases
+- Need to coordinate version updates with package building
+
+## Related Files & References
+
+### Project Configuration Files
+- `pyproject.toml` - Package metadata, build system (hatchling), dependencies, and tool configuration
+- `.releaserc.json` - Semantic-release configuration with exec plugin for version updates
+- `CONTRIBUTING.md` - Development workflow with uv commands and conventional commit format
+
+### Workflow Files
+- `.github/workflows/ci.yml` - Code quality validation using uv ecosystem (`uv sync`, `uv run`)
+- `.github/workflows/release.yml` - Automated release process using semantic-release
+- Current release workflow uses workflow_run trigger dependent on CI success
+
+### Development Environment
+- `justfile` - Command runner for development tasks including `just ci`
+- `uv` package manager - Used for dependency management, virtual environments, building, and publishing
+- Python 3.11+ requirement with uv-managed dev dependencies
+
+## Key Considerations
+
+### uv Ecosystem Consistency
+- **Native Tools**: Use `uv build` and `uv publish` instead of mixing pip/twine/external tools
+- **Performance**: Leverage uv's Rust-based speed throughout the pipeline
+- **Caching**: Utilize uv's built-in caching for dependencies and builds
+- **Workflow Alignment**: Maintain consistency with existing `uv sync` and `uv run` patterns
+
+### Security and Trust
+- **Trusted Publishing Preferred**: `uv publish --trusted-publishing automatic` eliminates API token management
+- **Repository Configuration**: Need to configure trusted publisher in PyPI project settings
+- **Environment Protection**: Consider using GitHub environments for additional approval gates
+- **Permissions**: Minimal required permissions (id-token: write, contents: read)
+
+### Integration Strategy
+- **Trigger Mechanism**: Tag creation events vs workflow_run vs semantic-release integration
+- **Version Coordination**: Ensure version in pyproject.toml matches tag version before build
+- **Build and Publish Timing**: Must build package after version update but before upload
+- **uv Workflow**: Use `astral-sh/setup-uv@v6` with caching for optimal performance
+
+### Testing and Validation
+- **TestPyPI Testing**: Use `uv publish --publish-url https://test.pypi.org/legacy/` for testing
+- **Package Installation**: Verify `uvx txtpack` works after publishing
+- **CI Integration**: Ensure publishing doesn't break if CI pipeline changes
+- **Error Handling**: Plan for network issues, validation errors, and retry scenarios
+
+### Backwards Compatibility
+- **Existing Workflows**: Must not break current uv-based CI/release process
+- **Development Experience**: Maintain current `just ci` and uv development commands
+- **Version Management**: Preserve semantic-release version bump behavior
+- **GitHub Releases**: Continue creating GitHub releases alongside PyPI publishing
+
+### Recommended Implementation Approach
+1. **Update semantic-release**: Modify `.releaserc.json` exec plugin `publishCmd` to use `uv publish --trusted-publishing automatic`
+2. **GitHub Actions**: Ensure release workflow has `id-token: write` permission for trusted publishing
+3. **PyPI Setup**: Configure trusted publisher for GitHub Actions in PyPI project settings
+4. **Testing**: Test with TestPyPI first using `--publish-url` override
+5. **Documentation**: Update installation instructions to include `uvx txtpack`
+
+## Manual PyPI Publishing for Existing Tags
+
+### GitHub Actions Manual Trigger Options
+
+#### Option 1: workflow_dispatch Trigger
+Add `workflow_dispatch` trigger to the PyPI publishing workflow to enable manual execution:
+
+```yaml
+name: PyPI Publish
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g., v1.0.0)'
+        required: true
+        type: string
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'pypi'
+        type: choice
+        options:
+        - pypi
+        - testpypi
+```
+
+**Usage**: Go to Actions tab → Select workflow → "Run workflow" → Enter tag name
+
+#### Option 2: GitHub CLI Command
+Trigger workflow manually using GitHub CLI:
+
+```bash
+# Publish specific tag to PyPI
+gh workflow run "PyPI Publish" \
+  --field tag=v1.0.0 \
+  --field environment=pypi
+
+# Publish to TestPyPI for testing
+gh workflow run "PyPI Publish" \
+  --field tag=v1.0.0 \
+  --field environment=testpypi
+```
+
+#### Option 3: Repository Dispatch Event
+Create a separate trigger workflow for on-demand publishing:
+
+```bash
+# Trigger via repository dispatch
+gh api repos/:owner/:repo/dispatches \
+  --method POST \
+  --field event_type=publish-pypi \
+  --field client_payload='{"tag":"v1.0.0","environment":"pypi"}'
+```
+
+### Workflow Implementation Considerations
+
+#### Tag Checkout Strategy
+Ensure the workflow checks out the specific tag:
+
+```yaml
+steps:
+  - name: Checkout specific tag
+    uses: actions/checkout@v4
+    with:
+      ref: ${{ inputs.tag || github.ref }}
+      fetch-depth: 0
+```
+
+#### Version Validation
+Validate that the pyproject.toml version matches the tag:
+
+```yaml
+  - name: Validate version consistency
+    run: |
+      TAG_VERSION=${{ inputs.tag || github.ref_name }}
+      TAG_VERSION=${TAG_VERSION#v}  # Remove 'v' prefix if present
+      PROJECT_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+      if [ "$TAG_VERSION" != "$PROJECT_VERSION" ]; then
+        echo "Version mismatch: tag=$TAG_VERSION, project=$PROJECT_VERSION"
+        exit 1
+      fi
+```
+
+#### Environment-Specific Publishing
+Support both PyPI and TestPyPI targets:
+
+```yaml
+  - name: Publish to PyPI
+    run: |
+      if [ "${{ inputs.environment }}" = "testpypi" ]; then
+        uv publish --trusted-publishing automatic --publish-url https://test.pypi.org/legacy/
+      else
+        uv publish --trusted-publishing automatic
+      fi
+```
+
+### Local Manual Publishing (Alternative)
+
+For immediate publishing without waiting for CI/CD:
+
+```bash
+# Checkout specific tag locally
+git checkout v1.0.0
+
+# Build distributions
+uv build
+
+# Publish to TestPyPI (testing)
+uv publish --publish-url https://test.pypi.org/legacy/ --token $TESTPYPI_TOKEN
+
+# Publish to PyPI (production) - requires API token for local use
+uv publish --token $PYPI_TOKEN
+
+# Or if you have trusted publishing configured locally (less common)
+uv publish --trusted-publishing automatic
+```
+
+**Note**: Local publishing requires API tokens since trusted publishing is primarily designed for CI/CD environments. The GitHub Actions approach is preferred for security and auditability.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
+    environment: pypi
 
     steps:
     - name: Checkout code
@@ -29,6 +30,11 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: "lts/*"
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
 
     - name: Install
       run: npm install @semantic-release/exec @semantic-release/changelog @semantic-release/git semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "sed -i 's/version = \".*\"/version = \"${nextRelease.version}\"/' pyproject.toml",
-        "publishCmd": "echo 'No PyPI publishing configured - git-based releases only'"
+        "publishCmd": "uv build && uv publish --trusted-publishing automatic"
       }
     ],
     [

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ The tool supports glob patterns for file selection and enables round-trip
 workflows where multiple files can be packed into a single stream
 and later reconstructed back to their original individual files.
 
+## Installation
+
+### Via uv (recommended)
+```bash
+uvx txtpack
+```
+
+### Via pip
+```bash
+pip install txtpack
+```
+
 ## Usage Examples
 
 ### Basic File Packing

--- a/docs/pypi.md
+++ b/docs/pypi.md
@@ -1,0 +1,230 @@
+# PyPI Trusted Publishing Setup
+
+This document provides step-by-step instructions for configuring PyPI trusted publishing with GitHub Actions for the txtpack package.
+
+## Overview
+
+PyPI trusted publishing uses OpenID Connect (OIDC) tokens to securely publish packages without storing API tokens. This setup enables automatic publishing when semantic-release creates new version tags.
+
+## Prerequisites
+
+- GitHub repository with txtpack code
+- PyPI account (create at https://pypi.org)
+- Repository admin access for environment configuration
+
+## Step 1: Configure PyPI Trusted Publishing
+
+### 1.1 Access PyPI Account Publishing Settings
+
+1. Go to https://pypi.org
+2. Sign in to your account
+3. Navigate to https://pypi.org/manage/account/publishing/
+4. Click "Add a new pending publisher"
+
+### 1.2 Configure Pending Publisher
+
+Fill in the pending publisher configuration:
+
+| Field | Value |
+|-------|--------|
+| **PyPI project name** | `txtpack` |
+| **Owner** | Your GitHub username or organization |
+| **Repository name** | `txtpack` |
+| **Workflow filename** | `release.yml` |
+| **Environment name** | `pypi` |
+
+### 1.3 Save Configuration
+
+Click "Add" to save the pending publisher configuration.
+
+**Important**:
+- Use "pending publisher" because the txtpack project doesn't exist on PyPI yet
+- The pending publisher will automatically become active when the first successful publish happens
+- The values must match exactly with your GitHub repository and workflow configuration
+
+## Step 2: Configure GitHub Environment
+
+### 2.1 Create Environment
+
+1. Go to your GitHub repository
+2. Click "Settings" tab
+3. In left sidebar, find "Code and automation" section
+4. Click "Environments"
+5. Click "New environment"
+6. Enter name: `pypi`
+7. Click "Configure environment"
+
+### 2.2 Configure Protection Rules (Recommended)
+
+For additional security, configure protection rules:
+
+#### Required Reviewers
+- **Purpose**: Require manual approval before PyPI publishing
+- **Setup**:
+  - Check "Required reviewers"
+  - Add maintainers who should approve releases
+  - Check "Prevent self-review" for additional security
+
+#### Wait Timer
+- **Purpose**: Add delay before publishing starts
+- **Setup**: Set timer (e.g., 5 minutes) to allow review time
+
+#### Deployment Branches
+- **Purpose**: Restrict publishing to specific branches
+- **Setup**:
+  - Select "Selected branches"
+  - Add rule for `main` branch
+
+### 2.3 Save Environment
+
+Click "Save protection rules" to complete environment setup.
+
+## Step 3: Verify Configuration
+
+### 3.1 Check Workflow Configuration
+
+Verify your `.github/workflows/release.yml` includes:
+
+```yaml
+permissions:
+  id-token: write  # Required for trusted publishing
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    environment: pypi  # Must match PyPI environment name
+```
+
+### 3.2 Check Semantic Release Configuration
+
+Verify `.releaserc.json` includes:
+
+```json
+{
+  "plugins": [
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "uv build && uv publish --trusted-publishing automatic"
+      }
+    ]
+  ]
+}
+```
+
+## Step 4: Test the Setup
+
+### 4.1 Trigger Release
+
+Create a test commit using conventional commit format:
+
+```bash
+git add .
+git commit -m "feat: test pypi publishing setup"
+git push origin main
+```
+
+### 4.2 Monitor Workflow
+
+1. Go to "Actions" tab in GitHub repository
+2. Watch the "Release" workflow execution
+3. If environment protection is enabled, approve the deployment when prompted
+4. Verify successful completion
+
+### 4.3 Verify Package Publication
+
+After successful workflow completion:
+
+```bash
+# Test installation with uv
+uvx txtpack --help
+
+# Test installation with pip
+pip install txtpack
+txtpack --help
+```
+
+Check package page: https://pypi.org/project/txtpack/
+
+## Step 5: Verify Publisher Activation
+
+After first successful publish:
+
+1. Go back to https://pypi.org/manage/account/publishing/
+2. Verify the pending publisher has been converted to an active publisher
+3. The txtpack project should now exist at https://pypi.org/project/txtpack/
+4. You can now manage the project directly at https://pypi.org/manage/project/txtpack/
+
+## Troubleshooting
+
+### Common Issues
+
+#### "Trusted publisher not configured"
+- Verify PyPI pending publisher settings match GitHub repository exactly
+- Check spelling of repository owner, name, workflow filename
+- Ensure environment name matches (`pypi`)
+
+#### "Environment protection rules failed"
+- Check if required reviewers are configured but haven't approved
+- Verify deployment branch rules allow publishing from current branch
+- Review environment protection settings
+
+#### "Permission denied (id-token)"
+- Confirm workflow has `id-token: write` permission
+- Verify job is running in correct environment (`environment: pypi`)
+
+#### "Package upload failed"
+- Check for version conflicts (semantic-release should handle automatically)
+- Verify package builds successfully with `uv build`
+- Review PyPI project name spelling
+
+#### "Pending publisher not found"
+- Verify you created the pending publisher at the account level (not project level)
+- Double-check all field values match exactly
+
+### Manual Publishing (Emergency)
+
+If automated publishing fails, publish manually:
+
+```bash
+# Build package
+uv build
+
+# Publish with API token (create token in PyPI settings)
+uv publish --token $PYPI_API_TOKEN
+```
+
+## Security Benefits
+
+- **No stored secrets**: Eliminates long-lived API tokens in repository
+- **Scoped access**: Publishing only works from specific GitHub workflows
+- **Audit trail**: All publications logged and traceable to commits
+- **Environment protection**: Additional approval gates for sensitive operations
+- **Automatic token rotation**: OIDC tokens are short-lived and automatically managed
+
+## Maintenance
+
+### Updating Configuration
+
+If you need to change repository name, workflow file, or environment:
+
+1. Update PyPI trusted publisher settings (or pending publisher)
+2. Update GitHub workflow configuration
+3. Update environment name if changed
+4. Test with new commit
+
+### Revoking Access
+
+To revoke publishing access:
+
+1. Remove trusted publisher from PyPI account settings
+2. Delete GitHub environment (optional)
+3. Remove publishing commands from semantic-release configuration
+
+## Additional Resources
+
+- [PyPI Trusted Publishing Documentation](https://docs.pypi.org/trusted-publishers/)
+- [GitHub Environments Documentation](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)
+- [uv Publishing Documentation](https://docs.astral.sh/uv/guides/publish/)


### PR DESCRIPTION
- Add comprehensive PyPI trusted publishing setup documentation
- Update semantic-release configuration to use uv publish with trusted publishing
- Enhance GitHub Actions release workflow with PyPI environment and uv setup
- Add installation instructions for uvx and pip in README
- Configure automated publishing pipeline triggered by semantic-release tags

Closes #4